### PR TITLE
Allocate the same memory for cl and trcl in percolation_calc_simple

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -62,7 +62,7 @@ endif
 ifeq ($(FC),gfortran)
 F90FLAGS = 
 DEBUG_FLAGS = 
-OFLAGS = -O2 -unshared
+OFLAGS = -O2 #-unshared
 LINKERFLAGS = 
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -62,7 +62,7 @@ endif
 ifeq ($(FC),gfortran)
 F90FLAGS = 
 DEBUG_FLAGS = 
-OFLAGS = -O2 #-unshared
+OFLAGS = -O2 -unshared
 LINKERFLAGS = 
 endif
 

--- a/src/percolation.f90
+++ b/src/percolation.f90
@@ -56,7 +56,7 @@ Contains
         Integer                                                                        :: nc
 
         allocate(cluster(size(lattice_in, 1), size(lattice_in, 2), size(lattice_in, 3)))
-        allocate(cl(100000),trcl(100000))
+        allocate(cl(5000000),trcl(5000000))
         nc = 0
         cluster = 0
         cl = 0


### PR DESCRIPTION
In a large system (N atoms: 106250) we encountered a segmentation fault error. With the gdb I found a place where the code crashes
```
Program received signal SIGSEGV, Segmentation fault.
0x000055555555b0ad in percolation::clusteranalysis (
    ngrid=<error reading variable: value requires 60160462 bytes, which is more than max-value-size>,
    cluster=<error reading variable: value requires 120320924 bytes, which is more than max-value-size>,
    cl=<error reading variable: value requires 400000 bytes, which is more than max-value-size>,
    trcl=<error reading variable: value requires 400000 bytes, which is more than max-value-size>, nc=136194) at percolation.f90:114
114            trcl_temp(i) = tempi
```
line 114 in percolation.f90;

looking further into the variables
```
(gdb) p tempi
$1 = 127475
(gdb) p i
$2 = 133581
```
where the size of tempi is 100000. Definitely index overflow for the array. I've set the size of these arrays the same as in the function `percolation_calc` and by these I was able to compute this large system.
cc: @zidan0x266