### PR TITLE
Poreblazer compilation on macOS M1

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ CMD = poreblazer.exe
 # Make sure it is defined
 #          ifeq ($(strip$(FORTRAN_COMPILER)),)
 # Otherwise you can define it here also by uncommenting next line
-FORTRAN_COMPILER= ifort
+FORTRAN_COMPILER= gfortran
 ifeq ($(FORTRAN_COMPILER),)
  FC = defaultCompiler
 else

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,6 +66,16 @@ OFLAGS = -O2 -unshared
 LINKERFLAGS = 
 endif
 
+
+# --------- Apple silicon (M1) override ----------------
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+  ifeq ($(FC),gfortran)
+    OFLAGS = -O2 -fcommon
+    LINKERFLAGS =
+  endif
+endif
+
 ### ------------ define flags for nagf95, intel-linux compiler by NAG ---------
 ###
 ###


### PR DESCRIPTION
This pull request adds a macOS-specific override for OFLAGS when compiling with gfortran on Apple M1 systems. Without this, the build fails due to the default gfortran behavior on ARM macOS.
	•	Adds a conditional check for Darwin (uname -s) and overrides OFLAGS to -O2 -fcommon.
	•	Updates the Makefile to set FORTRAN_COMPILER = gfortran by default, matching the instructions in the README.
	•	Keeps existing compiler sections intact, so this change is non-intrusive for other developers.
